### PR TITLE
Make NewsSiteMap useable!

### DIFF
--- a/src/formatting/NewsSiteMap.js
+++ b/src/formatting/NewsSiteMap.js
@@ -3,17 +3,26 @@ import xmlbuilder from 'xmlbuilder';
 
 import type { RawNewsSiteMapData } from '../types/sitemap';
 
-import PlainFormatter from './Plain';
 import newsSiteMapDataMapper from './formatNews';
+import createIndexSitemap from './formatIndex';
 
 import type { NewsSiteFormatter } from './index';
 
-export default class NewsSiteMapFormatter extends PlainFormatter implements NewsSiteFormatter {
-	openingTagNews = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" @xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">';
-	closingTagNews = '</urlset>';
+
+export default class NewsSiteMapFormatter implements NewsSiteFormatter {
+	xmlDeclaration = '<?xml version="1.0"?>';
+	openingTag = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" @xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">';
+	closingTag = '</urlset>';
 	// eslint-disable-next-line class-methods-use-this
-	formatNews(data: RawNewsSiteMapData[]): string {
+	format(data: RawNewsSiteMapData[]): string {
 		const mappedData = data.map(item => newsSiteMapDataMapper(item));
 		return xmlbuilder.begin().ele(mappedData).end();
+	}
+
+	// eslint-disable-next-line class-methods-use-this
+	formatIndex(data: any): string {
+		const { path, hostname, numberSitemaps } = data;
+		const xml = createIndexSitemap(numberSitemaps, hostname, path);
+		return xmlbuilder.create(xml, { encoding: 'UTF-8' }).end();
 	}
 }

--- a/src/formatting/index.js
+++ b/src/formatting/index.js
@@ -13,10 +13,12 @@ export interface Formatter {
 	formatIndex(data: any): string;
 }
 
-export interface NewsSiteFormatter extends Formatter {
-	openingTagNews: string;
-	closingTagNews: string;
-	formatNews(data: RawNewsSiteMapData[]): string;
+export interface NewsSiteFormatter {
+	xmlDeclaration: string;
+	openingTag: string;
+	closingTag: string;
+	format(data: RawNewsSiteMapData[]): string;
+	formatIndex(data: any): string;
 }
 
 export { PlainFormatter, NewsSiteMapFormatter };


### PR DESCRIPTION
Changes NewsSiteMap formatter to use format() instead of formatNews(). This way it can actually be used. However I’m not sure this is the end of the road. We could genaralise even more.